### PR TITLE
Replace OSM base layer with Mapbox satellite-streets-v11

### DIFF
--- a/app/assets/scripts/components/common/map/base-map-layer.js
+++ b/app/assets/scripts/components/common/map/base-map-layer.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import { TileLayer } from 'react-leaflet';
+import config from '../../../config';
 
 export const MAX_BASE_MAP_ZOOM_LEVEL = 19;
 
+const { mapboxAccessToken } = config;
+
 export const BaseMapLayer = () => (
   <TileLayer
-    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-    url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+    attribution='<a href="https://www.mapbox.com/about/maps/" target="_blank" title="Mapbox" aria-label="Mapbox" role="listitem">© Mapbox</a> <a href="https://www.openstreetmap.org/about/" target="_blank" title="OpenStreetMap" aria-label="OpenStreetMap" role="listitem">© OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/feedback/?owner=derilinx&amp;id=ckpwsqr6b3icr18qifl1h2e1d&amp;access_token=pk.eyJ1IjoiZGVyaWxpbngiLCJhIjoiY2szeTlzbWo2MDV6eDNlcDMxM3dzZXBieiJ9.zPf1iiFilYYwyx6ETNj_8w" target="_blank" title="Improve this map" aria-label="Improve this map" role="listitem">Improve this map</a>'
+    url={`https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxAccessToken}`}
     maxZoom={MAX_BASE_MAP_ZOOM_LEVEL}
   />
 );

--- a/app/assets/scripts/config/base.js
+++ b/app/assets/scripts/config/base.js
@@ -23,5 +23,7 @@ module.exports = {
     instanceCreationTimeout: 10 * 60 * 60 * 1000,
     instanceCreationCheckInterval: 5000,
     minimumAoiArea: 1000000,
+    mapboxAccessToken:
+      'pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJjbGdtajZjMXgwNjczM3JvZTg4bm42bjNtIn0.MJclBE_ARI264ZaotMoEjw',
   },
 };

--- a/app/assets/scripts/styles/vendor/leaflet.js
+++ b/app/assets/scripts/styles/vendor/leaflet.js
@@ -7,6 +7,13 @@ export default () => css`
     width: 30px;
   }
 
+  .leaflet-control-attribution {
+    a,
+    a:visited {
+      color: ${themeVal('color.baseDark')};
+    }
+  }
+
   .leaflet-control-geosearch {
     & form {
       border-radius: 4px;


### PR DESCRIPTION
Fix #35. 

This replaces the OSM base layer with Mapbox's satellite-streets-v11. I generated a new accessToken exclusive to Pearl.

@geohacker ready for review.