### PR TITLE
Fix small issues

### DIFF
--- a/app/assets/scripts/components/common/user-dropdown.js
+++ b/app/assets/scripts/components/common/user-dropdown.js
@@ -85,11 +85,6 @@ function UserDropdown() {
             </DropdownHeader>
             <DropdownBody>
               <li>
-                <DropdownItem as={StyledLink} to='/project/new' useIcon='globe'>
-                  New Project
-                </DropdownItem>
-              </li>
-              <li>
                 <DropdownItem
                   as={StyledLink}
                   to='/profile/projects'

--- a/app/assets/scripts/components/project/header/index.js
+++ b/app/assets/scripts/components/project/header/index.js
@@ -274,16 +274,18 @@ function ProjectPageHeader({ isMediumDown }) {
             <p>Export Options</p>
           </DropdownHeader>
           <DropdownBody>
-            <li>
-              <DropdownItem
-                useIcon='download-2'
-                onClick={() =>
-                  downloadShareGeotiff(restApiClient, currentShare)
-                }
-              >
-                Download .geotiff
-              </DropdownItem>
-            </li>
+            {currentShare && (
+              <li>
+                <DropdownItem
+                  useIcon='download-2'
+                  onClick={() =>
+                    downloadShareGeotiff(restApiClient, currentShare)
+                  }
+                >
+                  Download .geotiff
+                </DropdownItem>
+              </li>
+            )}
             <li>
               <DropdownItem
                 useIcon='link'


### PR DESCRIPTION
Updates:

- Remove "New Project" button from "Account" dropdown. The user now has to go to "My Project" page or Home to start a new project. To reinstante the button we need to add a FSM workflow that resets the context, which is not a super straightforward change
- Button "Download .geotiff" will be displayed only after the timeframe was exported

cc @geohacker 