### PR TITLE
Fix date format in cards

### DIFF
--- a/app/assets/scripts/components/project/prime-panel/tabs/predict/imagery-source-selector/modal.js
+++ b/app/assets/scripts/components/project/prime-panel/tabs/predict/imagery-source-selector/modal.js
@@ -8,6 +8,7 @@ import { Heading } from '@devseed-ui/typography';
 import CardList, { Card } from '../../../../../common/card-list';
 import { ProjectMachineContext } from '../../../../../../fsm/project';
 import selectors from '../../../../../../fsm/project/selectors';
+import { formatDateTime } from '../../../../../../utils/format';
 
 const ModalHeader = styled.header`
   padding: ${glsp(2)} ${glsp(2)} 0;
@@ -94,8 +95,8 @@ export function ImagerySourceSelectorModal({ showModal, setShowModal }) {
                 title={imagerySource.name}
                 details={{
                   name: imagerySource.name,
-                  created: imagerySource.created,
-                  updated: imagerySource.updated,
+                  created: formatDateTime(imagerySource.created),
+                  updated: formatDateTime(imagerySource.updated),
                 }}
                 borderlessMedia
                 selected={

--- a/app/assets/scripts/components/project/prime-panel/tabs/predict/mosaic-selector/modal.js
+++ b/app/assets/scripts/components/project/prime-panel/tabs/predict/mosaic-selector/modal.js
@@ -8,6 +8,7 @@ import { Heading } from '@devseed-ui/typography';
 import CardList, { Card } from '../../../../../common/card-list';
 import { ProjectMachineContext } from '../../../../../../fsm/project';
 import selectors from '../../../../../../fsm/project/selectors';
+import { formatDateTime } from '../../../../../../utils/format';
 
 const ModalHeader = styled.header`
   padding: ${glsp(2)} ${glsp(2)} 0;
@@ -93,14 +94,7 @@ export function MosaicSelectorModal({ showModal, setShowModal }) {
             numColumns={2}
             data={selectableMosaics}
             renderCard={(mosaic) => {
-              const {
-                id,
-                name,
-                created,
-                updated,
-                mosaic_ts_end,
-                mosaic_ts_start,
-              } = mosaic;
+              const { name, mosaic_ts_end, mosaic_ts_start } = mosaic;
 
               return (
                 <Card
@@ -108,12 +102,13 @@ export function MosaicSelectorModal({ showModal, setShowModal }) {
                   key={mosaic.id}
                   title={mosaic.name}
                   details={{
-                    id,
                     name,
-                    created,
-                    updated,
-                    mosaic_ts_end,
-                    mosaic_ts_start,
+                    'Mosaic Start Date': mosaic_ts_start
+                      ? formatDateTime(mosaic_ts_start)
+                      : 'N/A',
+                    'Mosaic End Date': mosaic_ts_end
+                      ? formatDateTime(mosaic_ts_end)
+                      : 'N/A',
                   }}
                   borderlessMedia
                   selected={currentMosaic && currentMosaic.id === mosaic.id}


### PR DESCRIPTION
This is a fix for #54. 

@LanesGood @geohacker I think we should also consider replacing the timestamps in imagery source cards with some other context, like a short text describing the source. The timestamps refer to database insert/update and doesn't look like to be of interest to end users. We can ticket in separate. This is ready for review.