### PR TITLE
Update pagination component to use ellipsis util

### DIFF
--- a/app/assets/scripts/components/admin/models/index.js
+++ b/app/assets/scripts/components/admin/models/index.js
@@ -111,7 +111,7 @@ export default function ModelIndex() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [models, setModels] = useState([]);
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const [total, setTotal] = useState(null);
   const [modelToDelete, setModelToDelete] = useState(null);
 
@@ -122,9 +122,7 @@ export default function ModelIndex() {
       try {
         showGlobalLoadingMessage('Loading models...');
         const data = await restApiClient.get(
-          `model/?active=all&storage=all&page=${
-            page - 1
-          }&limit=${ITEMS_PER_PAGE}`
+          `model/?active=all&storage=all&page=${page}&limit=${ITEMS_PER_PAGE}`
         );
         setTotal(data.total);
         setModels(data.models);
@@ -198,9 +196,9 @@ export default function ModelIndex() {
                     />
                     <Paginator
                       currentPage={page}
-                      gotoPage={setPage}
-                      totalItems={total}
-                      itemsPerPage={ITEMS_PER_PAGE}
+                      setPage={setPage}
+                      totalRecords={total}
+                      pageSize={ITEMS_PER_PAGE}
                     />
                   </>
                 ) : (

--- a/app/assets/scripts/components/admin/users/index.js
+++ b/app/assets/scripts/components/admin/users/index.js
@@ -105,7 +105,7 @@ export default function UserIndex() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [users, setUsers] = useState([]);
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const [total, setTotal] = useState(null);
 
   const { restApiClient } = useAuth();
@@ -115,7 +115,7 @@ export default function UserIndex() {
       try {
         showGlobalLoadingMessage('Loading users...');
         const data = await restApiClient.get(
-          `user/?sort=username&page=${page - 1}&limit=${ITEMS_PER_PAGE}`
+          `user/?sort=username&page=${page}&limit=${ITEMS_PER_PAGE}`
         );
         setTotal(data.total);
         setUsers(data.users);
@@ -161,9 +161,9 @@ export default function UserIndex() {
                     />
                     <Paginator
                       currentPage={page}
-                      gotoPage={setPage}
-                      totalItems={total}
-                      itemsPerPage={ITEMS_PER_PAGE}
+                      setPage={setPage}
+                      totalRecords={total}
+                      pageSize={ITEMS_PER_PAGE}
                     />
                   </>
                 ) : (

--- a/app/assets/scripts/components/common/paginator.js
+++ b/app/assets/scripts/components/common/paginator.js
@@ -1,136 +1,129 @@
 import React from 'react';
 import styled from 'styled-components';
 import T from 'prop-types';
-import fill from 'fill-range';
-
 import { Button } from '@devseed-ui/button';
 
-const PaginatorContainer = styled.section`
-  display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
-  text-align: center;
-  font-size: 0.875rem;
-`;
+import { themeVal, multiply } from '@devseed-ui/theme-provider';
+import { listPageOptions } from '../../utils/pagination-options';
 
-const Pager = styled.ul`
+const PaginationWrapper = styled.nav`
+  text-align: center;
+  margin: ${themeVal('layout.space')};
   display: flex;
+  flex-flow: row wrap;
   justify-content: center;
   align-items: center;
-  list-style: none;
-  list-style-type: none !important;
-  & > :not(:first-child) {
-    margin-left: 1rem;
-  }
-  ${Button} {
-    box-shadow: none;
-  }
 `;
 
-const PageButton = styled(Button)`
-  & ~ & {
-    margin-left: 0.5rem;
-  }
+const PaginationSummary = styled.div`
+  margin-top: ${themeVal('layout.space')};
+  font-size: ${multiply(themeVal('type.base.root'), 0.8)};
+  flex-basis: 100%;
 `;
 
-// Print range of page items
-// From https://stackoverflow.com/questions/47698412/pagination-in-javascript-showing-amount-of-elements-per-page
-function renderPageRange(totalItems, itemsPerPage) {
-  function getPageStart(pageSize, pageNr) {
-    return pageSize * pageNr;
+const PaginationButton = styled(Button)`
+  margin-left: ${multiply(themeVal('layout.space'), 0.5)};
+
+  &:first-child {
+    margin-left: 0;
   }
-
-  function getPageLabel(total, pageSize, pageNr) {
-    const start = Math.max(getPageStart(pageSize, pageNr), 0);
-    const end = Math.min(getPageStart(pageSize, pageNr + 1), total);
-
-    return `${start + 1} - ${end}`;
-  }
-
-  const size = itemsPerPage;
-  const pages = Array.from({ length: Math.ceil(totalItems / size) }, (_, i) =>
-    getPageLabel(totalItems, size, i)
-  );
-  return pages;
-}
-
+`;
 /**
  *
- * @param {Number} totalItems - total number of items
- * @param {Number} itemsPerPage - total number of pages
+ * @param {Number} totalRecords - total number of items
+ * @param {Number} pageSize - total number of pages
  * @param {Number} currentPage - current page
- * @param {Function} gotoPage - function to call to navigate to a page
+ * @param {Function} setPage - function to call to navigate to a page
  *                              (passed page number as param)
  */
-function Paginator({ currentPage, gotoPage, totalItems, itemsPerPage }) {
-  const numPages = Math.ceil(totalItems / itemsPerPage);
-  const hasPrev = currentPage > 1;
-  const hasNext = currentPage < numPages;
+function Paginator({ pageSize, currentPage, totalRecords, setPage }) {
+  const maxPages = pageSize ? Math.ceil(totalRecords / pageSize) : 0;
+  const pages = listPageOptions(currentPage + 1, maxPages);
+
   return (
-    <PaginatorContainer>
-      <Pager>
-        <li>
-          <Button
-            disabled={!hasPrev}
+    <PaginationWrapper>
+      <PaginationButton
+        data-cy='first-page-button'
+        onClick={() => setPage(0)}
+        disabled={currentPage === 0}
+        useIcon='chevron-left-trail--small'
+        hideText
+        variation='base-plain'
+        size='small'
+      >
+        First page
+      </PaginationButton>
+      <PaginationButton
+        data-cy='previous-page-button'
+        onClick={() => setPage(currentPage - 1)}
+        disabled={currentPage === 0}
+        useIcon='chevron-left--small'
+        hideText
+        variation='base-plain'
+        size='small'
+      >
+        Previous page
+      </PaginationButton>
+      {pages.map((page) => {
+        return (
+          <PaginationButton
+            onClick={() => setPage(page - 1)}
+            key={`page-${page}`}
+            variation={
+              page === '...'
+                ? 'base-plain'
+                : currentPage + 1 === page
+                ? 'primary-raised-dark'
+                : 'base-plain'
+            }
+            disabled={page === '...'}
+            data-cy={`page-${page}-button`}
             size='small'
-            variation='primary-raised-dark'
-            useIcon='chevron-left--small'
-            hideText
-            onClick={() => {
-              if (hasPrev) {
-                gotoPage(currentPage - 1);
-              }
-            }}
           >
-            Previous
-          </Button>
-        </li>
-        <li>
-          {fill(1, numPages).map((pageNumber) => (
-            <PageButton
-              key={pageNumber}
-              data-cy={`page-${pageNumber}-button`}
-              isCurrent={pageNumber === currentPage}
-              variation={
-                pageNumber === currentPage ? 'primary-plain' : 'base-plain'
-              }
-              onClick={() => gotoPage(pageNumber)}
-            >
-              {pageNumber}
-            </PageButton>
-          ))}
-        </li>
-        <li>
-          <Button
-            disabled={!hasNext}
-            size='small'
-            variation='primary-raised-dark'
-            useIcon='chevron-right--small'
-            data-cy='next-page-button'
-            hideText
-            onClick={() => {
-              if (hasNext) {
-                gotoPage(currentPage + 1);
-              }
-            }}
-          >
-            Next
-          </Button>
-        </li>
-      </Pager>
-      <div>
-        Showing {renderPageRange(totalItems, itemsPerPage)[currentPage - 1]} of{' '}
-        {totalItems}
-      </div>
-    </PaginatorContainer>
+            {page}
+          </PaginationButton>
+        );
+      })}
+      <PaginationButton
+        data-cy='next-page-button'
+        onClick={() => setPage(currentPage + 1)}
+        disabled={currentPage === maxPages - 1}
+        useIcon='chevron-right--small'
+        hideText
+        variation='base-plain'
+        size='small'
+      >
+        Next page
+      </PaginationButton>
+      <PaginationButton
+        data-cy='last-page-button'
+        onClick={() => setPage(maxPages - 1)}
+        disabled={currentPage === maxPages - 1}
+        useIcon='chevron-right-trail--small'
+        hideText
+        variation='base-plain'
+        size='small'
+      >
+        Last page
+      </PaginationButton>
+      <PaginationSummary>
+        Showing {currentPage * pageSize + 1}-
+        {Intl.NumberFormat().format(
+          currentPage === maxPages - 1
+            ? totalRecords
+            : (currentPage + 1) * pageSize
+        )}{' '}
+        of {Intl.NumberFormat().format(totalRecords)}
+      </PaginationSummary>
+    </PaginationWrapper>
   );
 }
 
 Paginator.propTypes = {
-  itemsPerPage: T.number,
-  currentPage: T.number,
-  gotoPage: T.func,
-  totalItems: T.number,
+  pageSize: T.number.isRequired,
+  currentPage: T.number.isRequired,
+  totalRecords: T.number.isRequired,
+  setPage: T.func.isRequired,
 };
 
 export default Paginator;

--- a/app/assets/scripts/components/profile/project/batch-list.js
+++ b/app/assets/scripts/components/profile/project/batch-list.js
@@ -140,11 +140,9 @@ BatchRow.propTypes = {
 };
 
 function BatchList({ projectId }) {
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const { isReady, data, hasError } = useFetch(
-    `project/${projectId}/batch?page=${
-      page - 1
-    }&limit=${TABLE_PAGE_SIZE}&order=desc`
+    `project/${projectId}/batch?page=${page}&limit=${TABLE_PAGE_SIZE}&order=desc`
   );
 
   if (!isReady) {
@@ -176,9 +174,9 @@ function BatchList({ projectId }) {
       />
       <Paginator
         currentPage={page}
-        gotoPage={setPage}
-        totalItems={data.total}
-        itemsPerPage={TABLE_PAGE_SIZE}
+        setPage={setPage}
+        totalRecords={data.total}
+        pageSize={TABLE_PAGE_SIZE}
       />
     </>
   );

--- a/app/assets/scripts/components/profile/project/project.js
+++ b/app/assets/scripts/components/profile/project/project.js
@@ -157,7 +157,7 @@ function Project() {
   const { apiToken } = useAuth();
   const history = useHistory();
   const { projectId } = useParams();
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const [total, setTotal] = useState(null);
   const [shares, setShares] = useState([]);
   const [isProjectLoading, setIsProjectLoading] = useState(true);
@@ -196,7 +196,7 @@ function Project() {
         setIsAoisLoading(true);
         try {
           const sharesData = await restApiClient.get(
-            `project/${projectId}/share?page=${page - 1}&limit=${AOIS_PER_PAGE}`
+            `project/${projectId}/share?page=${page}&limit=${AOIS_PER_PAGE}`
           );
           setTotal(sharesData.total);
           setShares(sharesData.shares);
@@ -326,9 +326,9 @@ function Project() {
                   />
                   <Paginator
                     currentPage={page}
-                    gotoPage={setPage}
-                    totalItems={total}
-                    itemsPerPage={AOIS_PER_PAGE}
+                    setPage={setPage}
+                    totalRecords={total}
+                    pageSize={AOIS_PER_PAGE}
                   />
                 </>
               ) : (

--- a/app/assets/scripts/components/profile/projects/projects.js
+++ b/app/assets/scripts/components/profile/projects/projects.js
@@ -81,7 +81,7 @@ function renderRow(proj) {
 function Projects() {
   const { apiToken } = useAuth();
 
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const [total, setTotal] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [projects, setProjects] = useState([]);
@@ -94,7 +94,7 @@ function Projects() {
         try {
           showGlobalLoadingMessage('Loading projects...');
           const data = await restApiClient.get(
-            `project/?page=${page - 1}&limit=${PROJECTS_PER_PAGE}`
+            `project/?page=${page}&limit=${PROJECTS_PER_PAGE}`
           );
           setTotal(data.total);
           setProjects(data.projects);
@@ -142,9 +142,9 @@ function Projects() {
                   />
                   <Paginator
                     currentPage={page}
-                    gotoPage={setPage}
-                    totalItems={total}
-                    itemsPerPage={PROJECTS_PER_PAGE}
+                    setPage={setPage}
+                    totalRecords={total}
+                    pageSize={PROJECTS_PER_PAGE}
                   />
                 </>
               ) : (

--- a/app/assets/scripts/components/public-maps/index.js
+++ b/app/assets/scripts/components/public-maps/index.js
@@ -224,7 +224,7 @@ function RenderSelectedRow(share, { compareMaps, setCompareMaps }) {
 function ExportedMapsList() {
   const { apiToken } = useAuth();
 
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const [total, setTotal] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [shares, setShares] = useState([]);
@@ -240,7 +240,7 @@ function ExportedMapsList() {
         try {
           setIsLoading(true);
           const data = await restApiClient.get(
-            `share/?page=${page - 1}&limit=${ITEMS_PER_PAGE}`
+            `share/?page=${page}&limit=${ITEMS_PER_PAGE}`
           );
           setTotal(data.total);
           setShares(data.shares);
@@ -316,9 +316,9 @@ function ExportedMapsList() {
                   />
                   <Paginator
                     currentPage={page}
-                    gotoPage={setPage}
-                    totalItems={total}
-                    itemsPerPage={ITEMS_PER_PAGE}
+                    setPage={setPage}
+                    totalRecords={total}
+                    pageSize={ITEMS_PER_PAGE}
                   />
                 </>
               ) : (

--- a/app/assets/scripts/utils/pagination-options.js
+++ b/app/assets/scripts/utils/pagination-options.js
@@ -1,0 +1,40 @@
+export function listPageOptions(page, lastPage) {
+  let pageOptions = [1];
+  if (lastPage === 1) {
+    return pageOptions;
+  }
+  if (page === 0 || page > lastPage) {
+    return pageOptions.concat([2, '...', lastPage]);
+  }
+  if (lastPage > 5) {
+    if (page < 3) {
+      return pageOptions.concat([2, 3, '...', lastPage]);
+    }
+    if (page === 3) {
+      return pageOptions.concat([2, 3, 4, '...', lastPage]);
+    }
+    if (page === lastPage) {
+      return pageOptions.concat(['...', page - 2, page - 1, lastPage]);
+    }
+    if (page === lastPage - 1) {
+      return pageOptions.concat(['...', page - 1, page, lastPage]);
+    }
+    if (page === lastPage - 2) {
+      return pageOptions.concat(['...', page - 1, page, page + 1, lastPage]);
+    }
+    return pageOptions.concat([
+      '...',
+      page - 1,
+      page,
+      page + 1,
+      '...',
+      lastPage,
+    ]);
+  } else {
+    let range = [];
+    for (let i = 1; i <= lastPage; i++) {
+      range.push(i);
+    }
+    return range;
+  }
+}


### PR DESCRIPTION
Closes #5 

Tested with large and small page sizes. Using the code from BRI, updated to catch previously noticed bugs, and pushing all pagination request math to the pagination component + util , rather than adding to the page number while fetching data in the component render.

Current page size:
![image](https://github.com/developmentseed/pearl-frontend/assets/12634024/42a7ad9b-84a9-4ba3-ade4-bdcba090fdad)

Small page size:
![image](https://github.com/developmentseed/pearl-frontend/assets/12634024/94e441ea-ba1d-409a-b7ee-a3709e9dc857)
