### PR TITLE
Only enable mosaic creation and selection for Sentinel imagery

### DIFF
--- a/app/assets/scripts/components/project/prime-panel/tabs/predict/mosaic-selector/index.js
+++ b/app/assets/scripts/components/project/prime-panel/tabs/predict/mosaic-selector/index.js
@@ -104,6 +104,9 @@ export function MosaicSelector() {
     label = 'Define first AOI';
   } else if (!currentImagerySource) {
     label = 'Define Imagery Source';
+  } else if (currentImagerySource.id !== 2) {
+    label = 'Mosaics unavailable for this imagery source';
+    disabled = true;
   } else {
     label = currentMosaic
       ? formatTimeframeLabel(


### PR DESCRIPTION
Sentinel mosaic creation is currently hardcoded; this PR restricts interaction with the mosaic creation/selection modal if any other imagery source is selected in a project.

<img width="374" alt="image" src="https://github.com/developmentseed/pearl-frontend/assets/12634024/5c672bd7-b1ad-4fdd-aebe-a3dd5d072674">
