### PR TITLE
Fetch timeframe stats after retrain

### DIFF
--- a/app/assets/scripts/fsm/project/machine.js
+++ b/app/assets/scripts/fsm/project/machine.js
@@ -678,6 +678,7 @@ export const projectMachine = createMachine(
             actions: [
               'hideGlobalLoading',
               'clearRetrainSamples',
+              'setCurrentTimeframe',
               'setCurrentTimeframeTilejson',
             ],
           },

--- a/app/assets/scripts/fsm/project/services.js
+++ b/app/assets/scripts/fsm/project/services.js
@@ -949,14 +949,18 @@ export const services = {
           });
           break;
         case 'model#prediction#complete':
-          apiClient
-            .get(
+          Promise.all([
+            apiClient.get(
+              `project/${project.id}/aoi/${currentAoi.id}/timeframe/${data.timeframe}`
+            ),
+            apiClient.get(
               `project/${project.id}/aoi/${currentAoi.id}/timeframe/${data.timeframe}/tiles`
-            )
-            .then((tilejson) => {
+            ),
+          ])
+            .then(([timeframe, tilejson]) => {
               callback({
                 type: 'Retrain run was completed',
-                data: { tilejson },
+                data: { timeframe, tilejson },
               });
             })
             .catch((error) => {


### PR DESCRIPTION
Fix #75. To test, run retrain and check if secondary panel is populated.

@LanesGood ready for review.