### PR TITLE
Reinstate layers panel

### DIFF
--- a/app/assets/scripts/components/explore/explore.js
+++ b/app/assets/scripts/components/explore/explore.js
@@ -18,7 +18,7 @@ import { useApiLimits } from '../../context/global';
 import { useSessionStatus } from '../../context/explore';
 import { sessionModes } from '../../context/explore/session-status';
 import { useParams } from 'react-router-dom';
-import LayersPanel from './layers-panel';
+// import LayersPanel from './layers-panel';
 
 const ExploreBody = styled(InpageBody)`
   display: grid;

--- a/app/assets/scripts/components/explore/explore.js
+++ b/app/assets/scripts/components/explore/explore.js
@@ -75,7 +75,7 @@ function Explore() {
           <ExploreCarto id='welcome-trigger'>
             <Map />
           </ExploreCarto>
-          <LayersPanel parentId='layer-control' className='padded' />
+          {/* <LayersPanel parentId='layer-control' className='padded' /> */}
           <SecPanel />
         </ExploreBody>
         {steps && !isLoading && <Tour steps={steps} />}

--- a/app/assets/scripts/components/project/layers-panel.js
+++ b/app/assets/scripts/components/project/layers-panel.js
@@ -8,7 +8,6 @@ import { themeVal, glsp } from '@devseed-ui/theme-provider';
 import InputRange from 'react-input-range';
 import { Accordion, AccordionFold as BaseFold } from '@devseed-ui/accordion';
 import throttle from 'lodash.throttle';
-import { ProjectMachineContext } from '../../fsm/project';
 import { round } from '../../utils/format';
 
 export const LayersPanelInner = styled.div`
@@ -205,32 +204,6 @@ function LayersPanel({
   mapLayers,
   setMapLayers,
 }) {
-  const currentCheckpoint = ProjectMachineContext.useSelector(
-    (s) => s.context.currentCheckpoint
-  );
-  const [userLayers, setUserLayers] = useState({
-    retrainingSamples: {
-      opacity: 0.3,
-      visible: true,
-      active: false,
-      id: 'retrainingSamples',
-      name: 'Retraining Samples',
-    },
-  });
-  // const { mapState, mapModes } = useMapState();
-  // const disabled = mapState.mode === mapModes.EDIT_AOI_MODE;
-
-  // const { userLayers: baseUserLayers, setUserLayers } = useUserLayers();
-  // // const { shortcutState, dispatchShortcutState } = useShortcutState();
-
-  // const userLayers = {
-  //   ...baseUserLayers,
-  //   predictions: {
-  //     ...baseUserLayers.predictions,
-  //     opacity: shortcutState.predictionLayerOpacity,
-  //   },
-  // };
-
   const [position, setPosition] = useState({});
 
   const parentNodeQuery = document.getElementById(parentId);
@@ -239,16 +212,6 @@ function LayersPanel({
   useEffect(() => {
     parentNode.current = parentNodeQuery;
   }, [parentNodeQuery]);
-
-  useEffect(() => {
-    setUserLayers({
-      ...userLayers,
-      retrainingSamples: {
-        ...userLayers.retrainingSamples,
-        active: currentCheckpoint && currentCheckpoint.retrain_geoms,
-      },
-    });
-  }, [currentCheckpoint && currentCheckpoint.retrain_geoms]);
 
   useEffect(() => {
     function updatePosition() {
@@ -286,64 +249,36 @@ function LayersPanel({
       <Accordion
         className={className}
         allowMultiple
-        foldCount={2}
-        initialState={[true, true]}
+        foldCount={1}
+        initialState={[true]}
       >
         {
           ({ checkExpanded, setExpanded }) => (
-            <>
-              <Category
-                checkExpanded={() => checkExpanded(0)}
-                setExpanded={(v) => setExpanded(0, v)}
-                category='User Layers'
-                layers={userLayers}
-                onSliderChange={(layer, value) => {
-                  setUserLayers({
-                    ...userLayers,
-                    [layer.id]: {
-                      ...layer,
-                      opacity: value,
-                      visible: value > 0,
-                    },
-                  });
-                }}
-                onVisibilityToggle={(layer) => {
-                  setUserLayers({
-                    ...userLayers,
-                    [layer.id]: {
-                      ...layer,
-                      visible: !layer.visible,
-                    },
-                  });
-                }}
-              />
-
-              <Category
-                checkExpanded={() => checkExpanded(1)}
-                setExpanded={(v) => setExpanded(1, v)}
-                category='Map Layers'
-                layers={mapLayers}
-                onSliderChange={(layer, value) => {
-                  setMapLayers({
-                    ...mapLayers,
-                    [layer.id]: {
-                      ...layer,
-                      opacity: value,
-                      visible: value > 0,
-                    },
-                  });
-                }}
-                onVisibilityToggle={(layer) => {
-                  setMapLayers({
-                    ...mapLayers,
-                    [layer.id]: {
-                      ...layer,
-                      visible: !layer.visible,
-                    },
-                  });
-                }}
-              />
-            </>
+            <Category
+              checkExpanded={() => checkExpanded(1)}
+              setExpanded={(v) => setExpanded(1, v)}
+              category='Map Layers'
+              layers={mapLayers}
+              onSliderChange={(layer, value) => {
+                setMapLayers({
+                  ...mapLayers,
+                  [layer.id]: {
+                    ...layer,
+                    opacity: value,
+                    visible: value > 0,
+                  },
+                });
+              }}
+              onVisibilityToggle={(layer) => {
+                setMapLayers({
+                  ...mapLayers,
+                  [layer.id]: {
+                    ...layer,
+                    visible: !layer.visible,
+                  },
+                });
+              }}
+            />
           )
           /* eslint-disable-next-line react/jsx-curly-newline */
         }
@@ -355,6 +290,10 @@ function LayersPanel({
 LayersPanel.propTypes = {
   className: T.string,
   parentId: T.string.isRequired,
+  active: T.bool,
+  mapLayers: T.object,
+  mapRef: T.object,
+  setMapLayers: T.func,
 };
 
 export default LayersPanel;

--- a/app/assets/scripts/components/project/layers-panel.js
+++ b/app/assets/scripts/components/project/layers-panel.js
@@ -2,16 +2,16 @@ import React, { useState, useEffect, useRef } from 'react';
 import T from 'prop-types';
 import styled, { css } from 'styled-components';
 import { Button } from '@devseed-ui/button';
-import InfoButton from '../../components/common/info-button';
+import InfoButton from '../common/info-button';
 import { Heading } from '@devseed-ui/typography';
 import { themeVal, glsp } from '@devseed-ui/theme-provider';
 import InputRange from 'react-input-range';
 import { Accordion, AccordionFold as BaseFold } from '@devseed-ui/accordion';
 import throttle from 'lodash.throttle';
-import { useMapLayers, useUserLayers, useMapRef } from '../../context/map';
-import { useMapState, useShortcutState } from '../../context/explore';
-import { actions as shortcutActions } from '../../context/explore/shortcuts';
-import { useCheckpoint } from '../../context/checkpoint';
+// import { useMapLayers, useUserLayers, useMapRef } from '../../context/map';
+// import { useMapState, useShortcutState } from '../../context/explore';
+// import { actions as shortcutActions } from '../../context/explore/shortcuts';
+// import { useCheckpoint } from '../../context/checkpoint';
 import { round } from '../../utils/format';
 
 export const LayersPanelInner = styled.div`
@@ -200,27 +200,69 @@ Category.propTypes = {
   onVisibilityToggle: T.func,
 };
 
-function LayersPanel(props) {
-  const { className, parentId } = props;
+function LayersPanel({
+  className,
+  parentId,
+  mapRef,
+  active,
+  mapLayers,
+  setMapLayers,
+}) {
 
-  const { mapState, mapModes } = useMapState();
-  const disabled = mapState.mode === mapModes.EDIT_AOI_MODE;
+  // const { mapState, mapModes } = useMapState();
+  // const disabled = mapState.mode === mapModes.EDIT_AOI_MODE;
 
-  const { userLayers: baseUserLayers, setUserLayers } = useUserLayers();
-  const { shortcutState, dispatchShortcutState } = useShortcutState();
+  // const { userLayers: baseUserLayers, setUserLayers } = useUserLayers();
+  // // const { shortcutState, dispatchShortcutState } = useShortcutState();
 
-  const userLayers = {
-    ...baseUserLayers,
-    predictions: {
-      ...baseUserLayers.predictions,
-      opacity: shortcutState.predictionLayerOpacity,
-    },
-  };
+  // const userLayers = {
+  //   ...baseUserLayers,
+  //   predictions: {
+  //     ...baseUserLayers.predictions,
+  //     // opacity: shortcutState.predictionLayerOpacity,
+  //   },
+  // };
 
-  const { mapLayers } = useMapLayers();
-  const { mapRef } = useMapRef();
-  const { currentCheckpoint } = useCheckpoint();
+  // const { mapLayers } = useMapLayers();
+  // const { mapRef } = useMapRef();
+  // const { currentCheckpoint } = useCheckpoint();
 
+  // const [position, setPosition] = useState({});
+
+  // const parentNodeQuery = document.getElementById(parentId);
+  // const parentNode = useRef();
+
+  // useEffect(() => {
+  //   parentNode.current = parentNodeQuery;
+  // }, [parentNodeQuery]);
+
+  // useEffect(() => {
+  //   setUserLayers({
+  //     ...userLayers,
+  //     retrainingSamples: {
+  //       ...userLayers.retrainingSamples,
+  //       active: currentCheckpoint && currentCheckpoint.retrain_geoms,
+  //     },
+  //   });
+  // }, [currentCheckpoint && currentCheckpoint.retrain_geoms]);
+
+  // useEffect(() => {
+  //   function updatePosition() {
+  //     if (parentNode.current) {
+  //       setPosition(parentNode.current.getBoundingClientRect());
+  //     }
+  //   }
+  //   const observer = new ResizeObserver(throttle(updatePosition, 100));
+
+  //   if (mapRef) {
+  //     observer.observe(mapRef.getContainer());
+  //   }
+  //   return () => mapRef && observer.unobserve(mapRef.getContainer());
+  // }, [mapRef, parentNode]);
+
+  // if (!parentNode) {
+  //   return null;
+  // }
   const [position, setPosition] = useState({});
 
   const parentNodeQuery = document.getElementById(parentId);
@@ -229,16 +271,6 @@ function LayersPanel(props) {
   useEffect(() => {
     parentNode.current = parentNodeQuery;
   }, [parentNodeQuery]);
-
-  useEffect(() => {
-    setUserLayers({
-      ...userLayers,
-      retrainingSamples: {
-        ...userLayers.retrainingSamples,
-        active: currentCheckpoint && currentCheckpoint.retrain_geoms,
-      },
-    });
-  }, [currentCheckpoint && currentCheckpoint.retrain_geoms]);
 
   useEffect(() => {
     function updatePosition() {
@@ -254,14 +286,10 @@ function LayersPanel(props) {
     return () => mapRef && observer.unobserve(mapRef.getContainer());
   }, [mapRef, parentNode]);
 
-  if (!parentNode) {
-    return null;
-  }
-
   return (
     <LayersPanelInner
       className={className}
-      show={!disabled && shortcutState.layerTray}
+      show={active}
       style={{
         top: position.top || 0,
         left: position.right || 0,
@@ -281,29 +309,20 @@ function LayersPanel(props) {
                 checkExpanded={() => checkExpanded(0)}
                 setExpanded={(v) => setExpanded(0, v)}
                 category='User Layers'
-                layers={userLayers}
+                layers={mapLayers}
                 onSliderChange={(layer, value) => {
-                  setUserLayers({
-                    ...userLayers,
+                  setMapLayers({
+                    ...mapLayers,
                     [layer.id]: {
                       ...layer,
                       opacity: value,
                       visible: value > 0,
                     },
                   });
-
-                  if (layer.id === 'predictions') {
-                    dispatchShortcutState({
-                      type: shortcutActions.UPDATE,
-                      data: {
-                        predictionLayerOpacity: value,
-                      },
-                    });
-                  }
                 }}
                 onVisibilityToggle={(layer) => {
-                  setUserLayers({
-                    ...userLayers,
+                  setMapLayers({
+                    ...mapLayers,
                     [layer.id]: {
                       ...layer,
                       visible: !layer.visible,

--- a/app/assets/scripts/components/project/map/index.js
+++ b/app/assets/scripts/components/project/map/index.js
@@ -31,16 +31,12 @@ import { RETRAIN_MAP_MODES } from '../../../fsm/project/constants';
 import FreehandDrawControl from './freehand-draw-control';
 import PolygonDrawControl from './polygon-draw-control';
 import selectors from '../../../fsm/project/selectors';
-import {
-  BOUNDS_PADDING,
-  MOSAIC_LAYER_OPACITY,
-} from '../../common/map/constants';
+import { BOUNDS_PADDING } from '../../common/map/constants';
 import { getMosaicTileUrl } from '../../../utils/mosaics';
 
 const center = [19.22819, -99.995841];
 const zoom = 12;
 
-const DEFAULT_PREDICTION_LAYER_OPACITY = 0.7;
 const INITIAL_MAP_LAYERS = {
   mosaic: {
     id: 'mosaic',
@@ -104,9 +100,6 @@ function Map() {
 
   // Local state
   const [mapRef, setMapRef] = useState();
-  const [predictionsOpacity, setPredictionsOpacity] = useState(
-    DEFAULT_PREDICTION_LAYER_OPACITY
-  );
   const [mapLayers, setMapLayers] = useState(INITIAL_MAP_LAYERS);
   const [showLayersControl, setShowLayersControl] = useState(false);
 
@@ -184,16 +177,41 @@ function Map() {
 
       if (e.key === 'a') {
         // On "a" key press, reduce opacity to zero
-        setPredictionsOpacity(0);
+        setMapLayers({
+          ...mapLayers,
+          predictions: {
+            ...mapLayers.predictions,
+            opacity: 0,
+            visible: false,
+          },
+        });
       } else if (e.key === 's') {
         // On "s" key press, reduce opacity by 10%
-        setPredictionsOpacity((prev) => prev - 0.1);
+        setMapLayers((prev) => ({
+          ...prev,
+          predictions: {
+            ...prev.predictions,
+            opacity: prev.predictions.opacity - 0.1,
+          },
+        }));
       } else if (e.key === 'd') {
         // On "d" key press, increase opacity by 10%
-        setPredictionsOpacity((prev) => prev + 0.1);
+        setMapLayers((prev) => ({
+          ...prev,
+          predictions: {
+            ...prev.predictions,
+            opacity: prev.predictions.opacity + 0.1,
+          },
+        }));
       } else if (e.key === 'f') {
         // On "f" key press, increase opacity to 100%
-        setPredictionsOpacity(1);
+        setMapLayers({
+          ...mapLayers,
+          predictions: {
+            ...mapLayers.predictions,
+            opacity: 1,
+          },
+        });
       } else if (e.key === ' ' || e.code === 'Space') {
         // On space keypress, pan map to current aoi bounds
         const aoiShape = currentAoiShape;
@@ -372,7 +390,7 @@ function Map() {
           <TileLayer
             key={mosaicTileUrl}
             url={mosaicTileUrl}
-            opacity={MOSAIC_LAYER_OPACITY}
+            opacity={mapLayers.mosaic.visible ? mapLayers.mosaic.opacity : 0}
           />
         )}
 
@@ -385,7 +403,9 @@ function Map() {
                 value: `Bearer ${apiToken}`,
               },
             ]}
-            opacity={predictionsOpacity}
+            opacity={
+              mapLayers.predictions.visible ? mapLayers.predictions.opacity : 0
+            }
           />
         )}
 
@@ -396,7 +416,11 @@ function Map() {
               key={p.key}
               url={p.image}
               bounds={p.bounds}
-              opacity={predictionsOpacity}
+              opacity={
+                mapLayers.predictions.visible
+                  ? mapLayers.predictions.opacity
+                  : 0
+              }
             />
           ))}
         <FeatureGroup>

--- a/app/assets/scripts/components/project/map/index.js
+++ b/app/assets/scripts/components/project/map/index.js
@@ -176,13 +176,13 @@ function Map() {
 
       if (e.key === 'a') {
         // On "a" key press, reduce opacity to zero
-        setMapLayers({
-          ...mapLayers,
+        setMapLayers((prev) => ({
+          ...prev,
           predictions: {
-            ...mapLayers.predictions,
+            ...prev.predictions,
             opacity: 0,
           },
-        });
+        }));
       } else if (e.key === 's') {
         // On "s" key press, reduce opacity by 10%
         setMapLayers((prev) => ({
@@ -203,13 +203,13 @@ function Map() {
         }));
       } else if (e.key === 'f') {
         // On "f" key press, increase opacity to 100%
-        setMapLayers({
-          ...mapLayers,
+        setMapLayers((prev) => ({
+          ...prev,
           predictions: {
-            ...mapLayers.predictions,
+            ...prev.predictions,
             opacity: 1,
           },
-        });
+        }));
       } else if (e.key === ' ' || e.code === 'Space') {
         // On space keypress, pan map to current aoi bounds
         const aoiShape = currentAoiShape;

--- a/app/assets/scripts/components/project/map/index.js
+++ b/app/assets/scripts/components/project/map/index.js
@@ -182,7 +182,6 @@ function Map() {
           predictions: {
             ...mapLayers.predictions,
             opacity: 0,
-            visible: false,
           },
         });
       } else if (e.key === 's') {

--- a/app/assets/scripts/components/project/map/index.js
+++ b/app/assets/scripts/components/project/map/index.js
@@ -124,7 +124,6 @@ function Map() {
   const currentTilejson = ProjectMachineContext.useSelector(
     selectors.currentTilejson
   );
-
   const currentMosaic = ProjectMachineContext.useSelector(
     selectors.currentMosaic
   );

--- a/app/assets/scripts/components/project/map/index.js
+++ b/app/assets/scripts/components/project/map/index.js
@@ -12,6 +12,8 @@ import {
   useMapEvent,
 } from 'react-leaflet';
 
+import LayersPanel from '../layers-panel';
+import GenericControl from '../../common/map/generic-control';
 import {
   MAX_BASE_MAP_ZOOM_LEVEL,
   BaseMapLayer,
@@ -39,6 +41,22 @@ const center = [19.22819, -99.995841];
 const zoom = 12;
 
 const DEFAULT_PREDICTION_LAYER_OPACITY = 0.7;
+const INITIAL_MAP_LAYERS = {
+  mosaic: {
+    id: 'mosaic',
+    name: 'Mosaic',
+    opacity: 1,
+    visible: true,
+    active: true,
+  },
+  predictions: {
+    id: 'predictions',
+    name: 'Prediction Results',
+    opacity: 1,
+    visible: true,
+    active: true,
+  },
+};
 
 const Container = styled.div`
   height: 100%;
@@ -89,6 +107,8 @@ function Map() {
   const [predictionsOpacity, setPredictionsOpacity] = useState(
     DEFAULT_PREDICTION_LAYER_OPACITY
   );
+  const [mapLayers, setMapLayers] = useState(INITIAL_MAP_LAYERS);
+  const [showLayersControl, setShowLayersControl] = useState(false);
 
   // FSM listeners
   const actorRef = ProjectMachineContext.useActorRef();
@@ -382,9 +402,24 @@ function Map() {
         <FeatureGroup>
           <GeoCoder />
           {currentAoiShape && <CenterMap aoiRef={currentAoiShape} />}
+          <GenericControl
+            id='layer-control'
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowLayersControl(!showLayersControl);
+            }}
+          />
         </FeatureGroup>
         <ScaleControl />
       </MapContainer>
+      <LayersPanel
+        mapRef={mapRef}
+        parentId='layer-control'
+        className='padded'
+        active={showLayersControl}
+        mapLayers={mapLayers}
+        setMapLayers={setMapLayers}
+      />
     </SizeAwareElement>
   );
 }

--- a/app/assets/scripts/components/share-map/layers-control.js
+++ b/app/assets/scripts/components/share-map/layers-control.js
@@ -42,6 +42,7 @@ function LayersPanel({
       style={{
         top: position.top || 0,
         left: position.right || 0,
+        zIndex: 500,
       }}
       show={active}
       data-cy='share-map-layers-panel'

--- a/app/assets/scripts/components/share-map/layers-control.js
+++ b/app/assets/scripts/components/share-map/layers-control.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import T from 'prop-types';
 import throttle from 'lodash.throttle';
 
-import { Category, LayersPanelInner } from '../explore/layers-panel';
+import { Category, LayersPanelInner } from '../project/layers-panel';
 import { Accordion } from '@devseed-ui/accordion';
 
 function LayersPanel({

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -20,7 +20,6 @@ import About from './components/about';
 import UhOh from './components/uhoh';
 import Projects from './components/profile/projects';
 
-import { GlobalContextProvider } from './context/global';
 import { CollecticonsGlobalStyle } from '@devseed-ui/collecticons';
 import GlobalLoadingProvider from './components/common/global-loading';
 import { ToastContainerCustom } from './components/common/toasts';
@@ -56,75 +55,73 @@ function Root() {
         <Router history={history}>
           <DevseedUiThemeProvider theme={theme.dark}>
             <GlobalLoadingProvider />
-            <GlobalContextProvider>
-              <CollecticonsGlobalStyle />
-              <GlobalStyles />
-              <Switch>
-                <Route exact path='/' component={Home} />
-                <Route exact path='/share/:uuid/map' component={ShareMap} />
-                <Route
-                  exact
-                  path='/compare/:leftUUID/:rightUUID'
-                  component={CompareMap}
-                />
-                <ProtectedRoute
-                  exact
-                  path='/public-maps'
-                  component={PublicMaps}
-                />
-                <ProtectedRoute
-                  path='/project-old/:projectId'
-                  component={Explore}
-                />
-                <ProtectedRoute
-                  path='/project/:projectId'
-                  component={ProjectPage}
-                />
-                <ProtectedRoute
-                  exact
-                  path='/profile/projects'
-                  component={Projects}
-                />
-                <ProtectedRoute
-                  exact
-                  path='/profile/projects/:projectId'
-                  component={Project}
-                />
-                <ProtectedRoute
-                  exact
-                  path='/admin/models'
-                  component={ModelIndex}
-                  access='admin'
-                />
-                <ProtectedRoute
-                  exact
-                  path='/admin/models/new'
-                  component={NewModel}
-                  access='admin'
-                />
-                <ProtectedRoute
-                  exact
-                  path='/admin/models/:modelId'
-                  component={ViewModel}
-                  access='admin'
-                />
-                <ProtectedRoute
-                  exact
-                  path='/admin/models/:modelId/upload'
-                  component={UploadModel}
-                  access='admin'
-                />
-                <ProtectedRoute
-                  exact
-                  path='/admin/users'
-                  component={UserIndex}
-                  access='admin'
-                />
-                <Route exact path='/about' component={About} />
-                <Route path='*' component={UhOh} />
-              </Switch>
-              <ToastContainerCustom />
-            </GlobalContextProvider>
+            <CollecticonsGlobalStyle />
+            <GlobalStyles />
+            <Switch>
+              <Route exact path='/' component={Home} />
+              <Route exact path='/share/:uuid/map' component={ShareMap} />
+              <Route
+                exact
+                path='/compare/:leftUUID/:rightUUID'
+                component={CompareMap}
+              />
+              <ProtectedRoute
+                exact
+                path='/public-maps'
+                component={PublicMaps}
+              />
+              <ProtectedRoute
+                path='/project-old/:projectId'
+                component={Explore}
+              />
+              <ProtectedRoute
+                path='/project/:projectId'
+                component={ProjectPage}
+              />
+              <ProtectedRoute
+                exact
+                path='/profile/projects'
+                component={Projects}
+              />
+              <ProtectedRoute
+                exact
+                path='/profile/projects/:projectId'
+                component={Project}
+              />
+              <ProtectedRoute
+                exact
+                path='/admin/models'
+                component={ModelIndex}
+                access='admin'
+              />
+              <ProtectedRoute
+                exact
+                path='/admin/models/new'
+                component={NewModel}
+                access='admin'
+              />
+              <ProtectedRoute
+                exact
+                path='/admin/models/:modelId'
+                component={ViewModel}
+                access='admin'
+              />
+              <ProtectedRoute
+                exact
+                path='/admin/models/:modelId/upload'
+                component={UploadModel}
+                access='admin'
+              />
+              <ProtectedRoute
+                exact
+                path='/admin/users'
+                component={UserIndex}
+                access='admin'
+              />
+              <Route exact path='/about' component={About} />
+              <Route path='*' component={UhOh} />
+            </Switch>
+            <ToastContainerCustom />
           </DevseedUiThemeProvider>
         </Router>
       </ErrorBoundary>


### PR DESCRIPTION
Closes #122.

<img width="1431" alt="image" src="https://github.com/developmentseed/pearl-frontend/assets/12634024/1e8a2a70-f124-49cf-a2bc-110c3ddc2caf">

This PR Reinstates the layers panel for mosaic and prediction opacity control. We can explore adding the retraining samples as a separate pr.

cc @vgeorge 