### PR TITLE
Do not block project loading if tilejson fetch failed

### DIFF
--- a/app/assets/scripts/fsm/project/services.js
+++ b/app/assets/scripts/fsm/project/services.js
@@ -307,9 +307,13 @@ export const services = {
       }
 
       if (nextTimeframe) {
-        nextTimeframe.tilejson = await apiClient.get(
-          `project/${projectId}/aoi/${context.currentAoi.id}/timeframe/${nextTimeframe.id}/tiles`
-        );
+        try {
+          nextTimeframe.tilejson = await apiClient.get(
+            `project/${projectId}/aoi/${context.currentAoi.id}/timeframe/${nextTimeframe.id}/tiles`
+          );
+        } catch (error) {
+          toasts.error('There was an error fetching the prediction layer.');
+        }
         nextMosaic = mosaicsList.find(
           (mosaic) => mosaic.id === nextTimeframe.mosaic
         );


### PR DESCRIPTION
This avoids blocking project load if the last prediction is "broken".

In the situation, the timeframe exists, but `GET /timeframe/:id/tiles` returns `AOI TimeFrame has not been uploaded` with 404 status. 

Before this fix, the UI would always redirect to the project page, making it impossible to load the project.

With the fix, a toast will be displayed and the user will be able to keep working on a project.

@LanesGood this one is hard to replicate as it depends on a backend failure. But it looks like a simple change to merge it if you think it is correct.