### PR TITLE
Add checkpoint name to batch list

### DIFF
--- a/app/assets/scripts/components/profile/project/batch-list.js
+++ b/app/assets/scripts/components/profile/project/batch-list.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import { Button } from '@devseed-ui/button';
@@ -28,6 +28,7 @@ const TABLE_HEADERS = [
   'AOI Size (KM2)',
   'Started',
   'Mosaic',
+  'Checkpoint',
   'Status',
   'Download',
 ];
@@ -103,6 +104,22 @@ const BatchRow = ({ batch, projectId }) => {
     created,
   } = batch;
   const [status, setStatus] = useState(getStatus(completed, abort, error));
+  const { restApiClient } = useAuth();
+  const [checkpointName, setCheckpointName] = useState();
+  useEffect(() => {
+    async function fetchCheckpointName() {
+      try {
+        const data = await restApiClient.getCheckpoint(
+          projectId,
+          timeframe.checkpoint_id
+        );
+        setCheckpointName(data.name);
+      } catch (error) {
+        logger(error);
+      }
+    }
+    fetchCheckpointName();
+  }, []);
 
   return (
     <TableRow key={id}>
@@ -113,6 +130,7 @@ const BatchRow = ({ batch, projectId }) => {
       <TableCell>
         {composeMosaicName(mosaic.mosaic_ts_start, mosaic.mosaic_ts_end)}
       </TableCell>
+      <TableCell>{checkpointName}</TableCell>
       <TableCell>
         {status === 'Processing' ? (
           <>

--- a/cypress/e2e/project/batch.cy.js
+++ b/cypress/e2e/project/batch.cy.js
@@ -523,12 +523,13 @@ describe('Batch predictions', () => {
 
     // Check available columns
     cy.get('th')
-      .should('have.length', 7)
+      .should('have.length', 8)
       .should('include.text', 'Id')
       .should('include.text', 'AOI Name')
       .should('include.text', 'AOI Size (KM2)')
       .should('include.text', 'Started')
       .should('include.text', 'Mosaic')
+      .should('include.text', 'Checkpoint')
       .should('include.text', 'Status')
       .should('include.text', 'Download');
 


### PR DESCRIPTION
This PR adds the checkpoint name for each batch to the batch list in the project page for greater distinction between batch exports. Without this, I am unable to distinguish between batches created for the same AOI using the same mosaic even if they are from different checkpoints.

The Batch endpoint doesn't return checkpoints, so I'm using the api client to fetch the name - this happens after row render.