### PR TITLE
Update timeframe list after retrain

### DIFF
--- a/app/assets/scripts/fsm/project/machine.js
+++ b/app/assets/scripts/fsm/project/machine.js
@@ -742,6 +742,7 @@ export const projectMachine = createMachine(
                   'hideGlobalLoading',
                   'clearRetrainSamples',
                   'clearCurrentPrediction',
+                  'setTimeframesList',
                   'setCurrentTimeframe',
                   'setCurrentTimeframeTilejson',
                 ],

--- a/app/assets/scripts/fsm/project/services.js
+++ b/app/assets/scripts/fsm/project/services.js
@@ -940,16 +940,19 @@ export const services = {
         case 'model#prediction#complete':
           Promise.all([
             apiClient.get(
+              `project/${project.id}/aoi/${currentAoi.id}/timeframe`
+            ),
+            apiClient.get(
               `project/${project.id}/aoi/${currentAoi.id}/timeframe/${data.timeframe}`
             ),
             apiClient.get(
               `project/${project.id}/aoi/${currentAoi.id}/timeframe/${data.timeframe}/tiles`
             ),
           ])
-            .then(([timeframe, tilejson]) => {
+            .then(([{ timeframes: timeframesList }, timeframe, tilejson]) => {
               callback({
                 type: 'Retrain run was completed',
-                data: { timeframe, tilejson },
+                data: { timeframesList, timeframe, tilejson },
               });
             })
             .catch((error) => {


### PR DESCRIPTION
May fix #148.

@LanesGood I believe what was happening is that the timeframe list wasn't being updated after retraining, so when you switch and go back to the last checkpoint the last timeframe is not available in the app state. This change should fix it.

How to test: create project, predict, retrain, switch to base model, switch to last checkpoint, timeframe list is correct. You can also confirm via the log messages related to timeframe list.
