### PR TITLE
Fix checkpoint selector race condition

### DIFF
--- a/app/assets/scripts/components/project/prime-panel/tabs/predict/checkpoint-selector.js
+++ b/app/assets/scripts/components/project/prime-panel/tabs/predict/checkpoint-selector.js
@@ -93,7 +93,11 @@ function CheckpointSelector() {
 
   if (sessionMode === SESSION_MODES.LOADING) {
     selectedOptionLabel = 'Loading...';
-  } else if (!checkpointList || checkpointList?.length === 0) {
+  } else if (
+    !checkpointList ||
+    checkpointList?.length === 0 ||
+    !currentCheckpoint
+  ) {
     selectedOptionLabel = 'Run model to create first checkpoint';
   } else {
     selectedOptionLabel = getCheckpointLabel(currentCheckpoint);


### PR DESCRIPTION
This fixes a small race condition where the `checkpointList` is populated but the `currentCheckpoint` isn't, causing a crash after running a first prediction on a new project.

@LanesGood this is a bit hard to replicate, let's merge if you think it is ok.