### PR TITLE
Fix project exported AOIs table 

### DIFF
--- a/app/assets/scripts/components/profile/project/project.js
+++ b/app/assets/scripts/components/profile/project/project.js
@@ -314,17 +314,19 @@ function Project() {
                   <Heading size='small'>
                     {project ? 'Exported Maps' : 'Loading Project...'}
                   </Heading>
-                  <Table
-                    headers={AOI_HEADERS}
-                    data={shares}
-                    renderRow={RenderRow}
-                    extraData={{
-                      project,
-                      restApiClient,
-                      shares,
-                      setShares,
-                    }}
-                  />
+                  {!isAoisLoading && (
+                    <Table
+                      headers={AOI_HEADERS}
+                      data={shares}
+                      renderRow={RenderRow}
+                      extraData={{
+                        project,
+                        restApiClient,
+                        shares,
+                        setShares,
+                      }}
+                    />
+                  )}
                   <Paginator
                     currentPage={page}
                     setPage={setPage}


### PR DESCRIPTION
Only render project AOI's table after AOIs are loaded.

Closes #160 